### PR TITLE
Initialize React app with TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # payment-processor-frontend
+
+This project was bootstrapped manually with a React and TypeScript setup. To get started, install dependencies and run the development server:
+
+```bash
+npm install
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "payment-processor-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>payment-processor-frontend</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders app title', () => {
+  render(<App />);
+  const linkElement = screen.getByText(/payment-processor-frontend/i);
+  expect(linkElement).toBeInTheDocument();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div className="App">
+      <h1>payment-processor-frontend</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,0 +1,15 @@
+import { ReportHandler } from 'web-vitals';
+
+const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold a React + TypeScript project
- add minimal app component and index
- include jest setup and basic test

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444a28b9f4832d8c18cda858245159